### PR TITLE
Move snap base to core26

### DIFF
--- a/.github/workflows/test-snap-can-build.yml
+++ b/.github/workflows/test-snap-can-build.yml
@@ -9,10 +9,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        node-version: [24.x]
-        
+
     steps:
       - uses: actions/checkout@v6
 

--- a/docs/CORE26_UPGRADE.md
+++ b/docs/CORE26_UPGRADE.md
@@ -45,7 +45,9 @@ Checklist:
    $SNAP/bin/hass --version
    ```
    If both resolve, keep it deleted (KISS win). If not, restore the block.
-5. **stage-packages parity on 26.04**: confirm every staged lib still exists with the same name on 26.04 (watch `libpcap0.8`, `libturbojpeg`, `libpulse0`, `ffmpeg` sonames). A renamed/removed lib only surfaces at runtime.
+5. **stage-packages parity on 26.04**: a renamed/removed lib fails the `Fetching stage-packages` step (or only surfaces at runtime). Known rename so far:
+   - `libturbojpeg` → **`libturbojpeg0`** (noble/24.04 used the unsuffixed name; resolute/26.04 ships the SONAME-suffixed `libturbojpeg0`). Already applied.
+   - Verified still valid on 26.04: `libglu1-mesa`, `libpcap0.8`(+`-dev`), `libpulse0`, `python3.14-venv`.
 6. **Runtime smoke test**:
    ```bash
    sudo snap install ./home-assistant-snap_*.snap --dangerous

--- a/docs/CORE26_UPGRADE.md
+++ b/docs/CORE26_UPGRADE.md
@@ -1,0 +1,62 @@
+# core26 Upgrade
+
+Notes and checklist for moving the snap base from `core24` to `core26`
+(Ubuntu Core 26 / Ubuntu 26.04 "Resolute Raccoon").
+
+## TL;DR — do the two "hacks" survive core26?
+
+| Hack | Where | Survives core26? |
+|------|-------|------------------|
+| **HA-core source patch** (`is_snap_env`) | `src/patches/0001-Detect-snap-environment.patch`, applied in `override-build` | **Still required.** It is *not* upstreamed (current HA `dev` `homeassistant/util/package.py` has no `is_snap_env`). core26 changes nothing here — it's HA-side, not base-side. |
+| **Interpreter symlink dance** (~55 lines copied from snapcraft's python plugin) | `override-build`, the `# look for a provisioned python interpreter` block | **Probably removable.** It existed because core24's base bundles `python3.12` while we want `python3.14`. From core26 the base bundles **no** Python and the python plugin is built around a staged interpreter, so the manual re-symlink should be unnecessary. **Must be verified by a real build** — see step 4. |
+
+## Why core26 matters for this snap
+
+- **No bundled Python.** From core26 onward the base snap ships no Python interpreter; the snap must stage its own. We already do (`stage-packages: python3.14-venv`, `build-packages: python3.14-dev`), so this is structurally in place.
+- **Ubuntu 26.04 ships `python3.14` in its archive**, so the `deadsnakes/ppa` we needed on the core24 (22.04) build base is no longer required. It is commented out in `snapcraft.yaml`, not deleted — restore in one line if a build can't find `python3.14{,-dev,-venv}`.
+
+## Changes already made on this branch
+
+- `snap/snapcraft.yaml`
+  - `base: core24` → `base: core26`
+  - `deadsnakes/ppa` `package-repositories` commented out (with restore note)
+  - App `environment` deduplicated via a YAML anchor (`&python-runtime-env` / `*python-runtime-env`) — was repeated across `home-assistant-snap` and `check-config`
+  - `override-build`: added a marker around the interpreter-symlink block flagging it as the core26 simplification candidate, and a clear header around the HA-core patch step (previously buried as the last line)
+- `.github/workflows/test-snap-can-build.yml`: removed the meaningless `node-version` build matrix (there is no Node in this project)
+
+## Build-verification procedure (required — not done in CI here)
+
+A full Home Assistant build is large (hundreds of wheels, ffmpeg, etc.). Use LXD on the dev box:
+
+```bash
+# from the repo root, on the core26-capable build host
+SNAPCRAFT_BUILD_ENVIRONMENT=lxd snapcraft --verbose
+```
+
+Checklist:
+
+1. **Toolchain**: `snapcraft --version` supports `core26`; `core26` base snap installed (`snap install core26`).
+2. **Python provisioning**: build finds `python3.14`. If it fails on a missing `python3.14*` package, uncomment the deadsnakes block in `snapcraft.yaml`.
+3. **Patch applies**: the `patch -p1` step succeeds against the pinned HA tag (`version:` in `snapcraft.yaml`). It currently applies cleanly to `2026.6.4`. Patch drift risk is on *future HA bumps*, not on core26.
+4. **Try dropping the interpreter hack**: delete the marked block in `override-build` (everything from `# look for a provisioned python interpreter` down to the `ln -sf …` line) and rebuild. Confirm:
+   ```bash
+   # inside the built snap / staged part
+   $SNAP/bin/python3.14 --version
+   $SNAP/bin/hass --version
+   ```
+   If both resolve, keep it deleted (KISS win). If not, restore the block.
+5. **stage-packages parity on 26.04**: confirm every staged lib still exists with the same name on 26.04 (watch `libpcap0.8`, `libturbojpeg`, `libpulse0`, `ffmpeg` sonames). A renamed/removed lib only surfaces at runtime.
+6. **Runtime smoke test**:
+   ```bash
+   sudo snap install ./home-assistant-snap_*.snap --dangerous
+   snap run home-assistant-snap.check-config
+   # then confirm the patch took effect:
+   # Settings → System → Repairs → System information should show
+   # installation_type: "Home Assistant Snap"
+   ```
+7. **Confinement**: `confinement: strict` still passes `diddlesnaps/snapcraft-review-action`.
+
+## Follow-ups (not blockers)
+
+- **Upstream `is_snap_env` to HA core.** The patch author (`ThyMYthOS` / Manuel Stahl) is already a reviewer on the auto-update workflow. Landing it upstream removes the patch entirely and kills the biggest per-release fragility.
+- **Re-enable the `updater` component** (the part is commented out in `snapcraft.yaml` while `README.md` advertises `binary_sensor.updater`). Before shipping it, address the latent bugs noted in the audit (`Tracks.get_latest()` risk/name conflation, `get_risk()` str|int return, the `snap_rev[0] == 'x'` heuristic).

--- a/docs/CORE26_UPGRADE.md
+++ b/docs/CORE26_UPGRADE.md
@@ -22,6 +22,7 @@ Notes and checklist for moving the snap base from `core24` to `core26`
   - `deadsnakes/ppa` `package-repositories` commented out (with restore note)
   - App `environment` deduplicated via a YAML anchor (`&python-runtime-env` / `*python-runtime-env`) — was repeated across `home-assistant-snap` and `check-config`
   - `override-build`: added a marker around the interpreter-symlink block flagging it as the core26 simplification candidate, and a clear header around the HA-core patch step (previously buried as the last line)
+  - `snapcraft-preload` part: added `-DCMAKE_POLICY_VERSION_MINIMUM=3.5` — 26.04 ships CMake 4.x, which removed compatibility with the pre-3.5 `cmake_minimum_required()` in upstream snapcraft-preload
 - `.github/workflows/test-snap-can-build.yml`: removed the meaningless `node-version` build matrix (there is no Node in this project)
 
 ## Build-verification procedure (required — not done in CI here)

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -70,7 +70,7 @@ description: |
 # donation: "https://www.paypal.com/donate/?hosted_button_id=69NA8SXXFBDBN"
 license: Apache-2.0
 
-base: core24
+base: core26
 grade: stable
 confinement: strict
 
@@ -119,7 +119,7 @@ apps:
       - bin/snapcraft-preload
       - bin/plug-bin
     daemon: simple
-    environment:
+    environment: &python-runtime-env
       PATH: $SNAP/bin:$PATH
       PYTHONUSERBASE: $SNAP_DATA/deps
       UV_CACHE_DIR: $SNAP_COMMON/.cache
@@ -143,16 +143,17 @@ apps:
       - desktop
 
   check-config:
-    plugs: 
+    plugs:
       - network
-    environment:
-      PYTHONUSERBASE: $SNAP_DATA/deps
-      UV_CACHE_DIR: $SNAP_COMMON/.cache
+    environment: *python-runtime-env
     command: bin/hass --script check_config --config $SNAP_DATA -i
 
-package-repositories:
- - type: apt
-   ppa: deadsnakes/ppa
+# core26 builds on Ubuntu 26.04, which ships python3.14 in the archive, so the
+# deadsnakes PPA (needed on the core24/22.04 build base) is no longer required.
+# If a build fails to find python3.14{,-dev,-venv}, restore by uncommenting:
+# package-repositories:
+#  - type: apt
+#    ppa: deadsnakes/ppa
 
 parts:
   snapcraft-preload:
@@ -224,6 +225,17 @@ parts:
       find "${HA_INSTALL_DIR}" -type f -executable -print0 | xargs --no-run-if-empty -0 \
           sed -i "1 s|^#\!${PARTS_PYTHON_VENV_INTERP_PATH}.*$|#!/usr/bin/env ${PARTS_PYTHON_INTERPRETER}|"
 
+      # ---------------------------------------------------------------------
+      # core26 SIMPLIFICATION CANDIDATE:
+      # The block below is a copy of snapcraft's python-plugin internals
+      # (_get_system_python_interpreter) used on core24 to re-point the venv at
+      # a staged python3.14 instead of the base's bundled python3.12. On core26
+      # the base ships NO python and the python plugin is designed around a
+      # staged interpreter, so this manual symlink dance is likely unnecessary.
+      # During the core26 build, try DELETING this block (down to the `ln -sf`)
+      # and verify `${HA_INSTALL_DIR}/bin/python3.14 --version` still resolves.
+      # See docs/CORE26_UPGRADE.md.
+      # ---------------------------------------------------------------------
       # look for a provisioned python interpreter
       opts_state="$(set +o|grep errexit)"
       set +e
@@ -261,6 +273,13 @@ parts:
       eval "${opts_state}"
 
       ln -sf "${symlink_target}" "${PARTS_PYTHON_VENV_INTERP_PATH}"
+
+      # ---------------------------------------------------------------------
+      # PATCH HOME ASSISTANT CORE (out-of-tree, NOT upstreamed):
+      # Applies src/patches/*.patch to the installed homeassistant package so
+      # it detects the snap environment (adds is_snap_env). Runs under `set -e`,
+      # so a context mismatch after an HA bump aborts the build loudly.
+      # ---------------------------------------------------------------------
       (cd "${CRAFT_PART_INSTALL}/lib/python3.14/site-packages" && ls ${CRAFT_PROJECT_DIR}/src/patches/*.patch | xargs -n1 patch -p1 -i)
     
     stage-packages:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -161,6 +161,9 @@ parts:
     plugin: cmake
     cmake-parameters:
       - -DCMAKE_INSTALL_PREFIX=/
+      # 26.04 ships CMake 4.x, which removed compat with the pre-3.5
+      # cmake_minimum_required() in upstream snapcraft-preload. Allow it.
+      - -DCMAKE_POLICY_VERSION_MINIMUM=3.5
     build-packages:
       - on amd64:
         - gcc-multilib

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -290,7 +290,7 @@ parts:
       - libpcap0.8
       - libpcap0.8-dev
       - libpulse0
-      - libturbojpeg
+      - libturbojpeg0  # core26/26.04 renamed this from `libturbojpeg` (noble/core24)
       - netbase
       - python3.14-venv
       - tcpdump


### PR DESCRIPTION
## Summary

Moves the snap base from `core24` to **`core26`** (Ubuntu Core 26 / 26.04).

✅ **Build-verified** — CI built the full snap on a managed Ubuntu 26.04 instance and passed snap review ([run](https://github.com/giaever-online-iot/home-assistant-snap/actions/runs/27976945453)).

Rescoped per review: the shebang fix went directly to master (96eca24) and the updater fixes are now #75. This PR is core26 only (plus a small CI matrix cleanup, which #76 supersedes).

## Changes
- `base: core24` → `core26`
- **deadsnakes PPA disabled** — 26.04 ships `python3.14` in its archive (confirmed: build-packages incl. `python3.14-dev` install fine on 26.04), so the PPA needed on the core24 build base is no longer required.
- `libturbojpeg` → **`libturbojpeg0`** — 26.04 renamed the runtime package (SONAME-suffixed).
- `snapcraft-preload`: added `-DCMAKE_POLICY_VERSION_MINIMUM=3.5` — 26.04's CMake 4.x dropped pre-3.5 compat.
- Dedup app `environment` via a YAML anchor/alias.
- `override-build`: surfaced the HA-core patch step and flagged the copied interpreter-symlink block as a **core26 simplification candidate** (left in place — build passes with it; removing it is a future KISS experiment, see docs).
- New `docs/CORE26_UPGRADE.md`.

### Hacks — confirmed by the build
- **HA-core `is_snap_env` patch — still required and still applies cleanly** (all 4 files / all hunks succeeded against `2026.6.4` on core26; not upstreamed).
- **Interpreter-symlink dance** — still present; build is green with it. Test-removing it is the open follow-up in the upgrade doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)