### PR TITLE
ci: drop Node 20/12 actions, drive snapcraft directly

### DIFF
--- a/.github/workflows/auto-update.yml
+++ b/.github/workflows/auto-update.yml
@@ -93,17 +93,32 @@ jobs:
           # Verify the change
           grep "^version:" snap/snapcraft.yaml
 
-      - name: Build snap
+      # Drive snapcraft directly instead of the deprecated Node-runtime actions
+      # (snapcore/action-build@v1 = Node 20, diddlesnaps review = Node 12).
+      - name: Set up LXD and Snapcraft
         if: steps.check.outputs.should_create_pr == 'true' && steps.check_pr.outputs.pr_exists == 'false'
-        uses: snapcore/action-build@v1
+        run: |
+          sudo groupadd --force --system lxd
+          sudo usermod --append --groups lxd "$USER"
+          sudo snap install lxd
+          sudo lxd init --auto
+          sudo iptables -P FORWARD ACCEPT
+          sudo snap install snapcraft --classic
+
+      - name: Build snap
         id: build
+        if: steps.check.outputs.should_create_pr == 'true' && steps.check_pr.outputs.pr_exists == 'false'
+        env:
+          SNAPCRAFT_BUILD_ENVIRONMENT: lxd
+        run: |
+          sg lxd -c 'snapcraft pack --verbose'
+          echo "snap=$(ls -1 *.snap | head -1)" >> "$GITHUB_OUTPUT"
 
       - name: Review snap
         if: steps.check.outputs.should_create_pr == 'true' && steps.check_pr.outputs.pr_exists == 'false'
-        uses: diddlesnaps/snapcraft-review-action@v1
-        with:
-          snap: ${{ steps.build.outputs.snap }}
-          isClassic: 'false'
+        run: |
+          sudo snap install review-tools
+          review-tools.snap-review "${{ steps.build.outputs.snap }}"
 
       - name: Upload snap artifact
         if: steps.check.outputs.should_create_pr == 'true' && steps.check_pr.outputs.pr_exists == 'false'

--- a/.github/workflows/test-snap-can-build.yml
+++ b/.github/workflows/test-snap-can-build.yml
@@ -5,24 +5,35 @@ on:
     branches: [ master ]
   pull_request:
     branches: [ master ]
-    
+
 jobs:
   build:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        node-version: [24.x]
-        
+
     steps:
       - uses: actions/checkout@v6
 
-      - uses: snapcore/action-build@v1
-        id: build
+      # Drive snapcraft directly instead of snapcore/action-build@v1 (Node 20)
+      # and diddlesnaps/snapcraft-review-action@v1 (Node 12), both of which
+      # emit GitHub "Node.js is deprecated" warnings and have no Node 24
+      # release. The steps below mirror what action-build does internally, but
+      # invoke `snapcraft pack` (bare `snapcraft` is itself deprecated).
+      - name: Set up LXD and Snapcraft
+        run: |
+          sudo groupadd --force --system lxd
+          sudo usermod --append --groups lxd "$USER"
+          sudo snap install lxd
+          sudo lxd init --auto
+          # docker (preinstalled on the runner) can break LXD networking
+          sudo iptables -P FORWARD ACCEPT
+          sudo snap install snapcraft --classic
 
-      - uses: diddlesnaps/snapcraft-review-action@v1
-        with:
-          snap: ${{ steps.build.outputs.snap }}
-          isClassic: 'false'
-          # Plugs and Slots declarations to override default denial (requires store assertion to publish)
-#          plugs: ./plug-declaration.json
-#          slots: ./slot-declaration.json
+      - name: Build snap
+        env:
+          SNAPCRAFT_BUILD_ENVIRONMENT: lxd
+        run: sg lxd -c 'snapcraft pack --verbose'
+
+      - name: Review snap
+        run: |
+          sudo snap install review-tools
+          review-tools.snap-review *.snap


### PR DESCRIPTION
Addresses the deprecation warning ThyMYthOS flagged on #74 (https://github.com/giaever-online-iot/home-assistant-snap/pull/74#issuecomment-4771575493).

## Why a bump isn't enough
- `snapcore/action-build` — latest `v1.3.0` (and `master`) still declare `using: 'node20'`; there is **no** Node 24 / v2 release.
- `diddlesnaps/snapcraft-review-action@v1.3.1` is worse: `using: 'node12'`.

So the warning can't be cleared by pinning a newer tag — the actions themselves haven't migrated. This replaces them with direct steps.

## Changes
- **`test-snap-can-build.yml`** and **`auto-update.yml`**: replace `snapcore/action-build@v1` + `diddlesnaps/snapcraft-review-action@v1` with direct `snapcraft pack` + `review-tools.snap-review`, mirroring action-build's internal LXD setup.
- Using `snapcraft pack` (not bare `snapcraft`) also clears the second deprecation in the logs: *"Running snapcraft without a command will not be possible in future releases."*
- `auto-update.yml`: the build step now exports `snap=<file>` to `$GITHUB_OUTPUT` so the existing artifact-upload/PR steps keep working unchanged.
- Drops the no-op `node-version` matrix from `test-snap-can-build.yml`.

## Validation
`test-snap-can-build.yml` runs on this PR, so its build path is self-validated by CI here. `auto-update.yml` only runs on schedule/dispatch and mirrors the identical pattern.

## Note on overlap with #74
This and #74 both edit `test-snap-can-build.yml`. Whichever merges second should take this PR's version of that file (full job rewrite). Branched off `master`, so it builds the current **core24** snap — intentionally independent of the core26 base move.

🤖 Generated with [Claude Code](https://claude.com/claude-code)